### PR TITLE
Divide census enhancements

### DIFF
--- a/dbt_hdpt/models/marts/_int_models.yml
+++ b/dbt_hdpt/models/marts/_int_models.yml
@@ -29,3 +29,21 @@ models:
               values: [0]
           - not_null
   - name: int_census_tract_gtfs_aggregated
+  - name: int_census_tract_land_area_enriched
+    columns:
+      - name: census_tract
+        type: primary key
+        description: Foreign key to the census tract which the stop is located in. Derived via stop_lat and stop_long using Python package [censusgeocode](https://pypi.org/project/censusgeocode/).
+        data_tests:
+          - unique
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: varchar
+      - name: tract_land_sq_meters
+        description: Derived using Census Data API from U.S. Census Bureau. "Annual Geographic Information Table" Geography, GEO Geography Information, Table GEOINFO, -1, https://data.census.gov/table/GEOINFO2023.GEOINFO?q=GEOINFO: Accessed on June 14, 2025.
+        data_tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: integer
+          - dbt_utils.not_accepted_values:
+              values: [0]
+          - not_null

--- a/dbt_hdpt/models/marts/_int_models.yml
+++ b/dbt_hdpt/models/marts/_int_models.yml
@@ -40,7 +40,7 @@ models:
           - dbt_expectations.expect_column_values_to_be_of_type:
               column_type: varchar
       - name: tract_land_sq_meters
-        description: Derived using Census Data API from U.S. Census Bureau. "Annual Geographic Information Table" Geography, GEO Geography Information, Table GEOINFO, -1, https://data.census.gov/table/GEOINFO2023.GEOINFO?q=GEOINFO: Accessed on June 14, 2025.
+        description: "Derived using Census Data API from U.S. Census Bureau. 'Annual Geographic Information Table' Geography, GEO Geography Information, Table GEOINFO, -1, https://data.census.gov/table/GEOINFO2023.GEOINFO?q=GEOINFO: Accessed on June 14, 2025."
         data_tests:
           - dbt_expectations.expect_column_values_to_be_of_type:
               column_type: integer

--- a/dbt_hdpt/models/marts/int_census_tract_land_area_enriched.py
+++ b/dbt_hdpt/models/marts/int_census_tract_land_area_enriched.py
@@ -25,6 +25,7 @@ def model(dbt, session):
     # Select and clean relevant columns
     selected = data_df[["NAME", "AREALAND"]].copy()
     selected["NAME"] = selected["NAME"].str.split(";").str[0]
+    selected["AREALAND"] = pd.to_numeric(selected["AREALAND"])
     selected = selected.rename(columns={
         "NAME": "census_tract",
         "AREALAND": "tract_land_sq_meters"

--- a/dbt_hdpt/models/marts/int_census_tract_land_area_enriched.py
+++ b/dbt_hdpt/models/marts/int_census_tract_land_area_enriched.py
@@ -1,0 +1,33 @@
+import os
+import pandas as pd
+import requests
+
+def model(dbt, session):
+    # Get API key from environment variable
+    CENSUS_API_KEY = os.environ["CENSUS_API_KEY"]
+
+    params = {
+        "get": "group(GEOINFO)",
+        "ucgid": "pseudo(0500000US37119$1400000)",
+        "key": CENSUS_API_KEY
+    }
+
+    url = "https://api.census.gov/data/2023/geoinfo"
+
+    # Make the request
+    response = requests.get(url, params=params)
+    response.raise_for_status()
+
+    # Parse the JSON response
+    data = response.json()
+    data_df = pd.DataFrame(data[1:], columns=data[0])
+
+    # Select and clean relevant columns
+    selected = data_df[["NAME", "AREALAND"]].copy()
+    selected["NAME"] = selected["NAME"].str.split(";").str[0]
+    selected = selected.rename(columns={
+        "NAME": "census_tract",
+        "AREALAND": "tract_land_sq_meters"
+    })
+
+    return selected

--- a/dbt_hdpt/models/marts/int_gtfs_stops_enriched.py
+++ b/dbt_hdpt/models/marts/int_gtfs_stops_enriched.py
@@ -11,11 +11,9 @@ def geocode_coordinates(row):
     
     # Extract the relevant fields
     census_tract = tract.get('NAME')
-    tract_land_sq_meters = tract.get('AREALAND')
     
     return pd.Series({
-        'census_tract': str(census_tract),
-        'tract_land_sq_meters': int(tract_land_sq_meters)
+        'census_tract': str(census_tract)
     })
 
 def model(dbt, session):


### PR DESCRIPTION
Removes fetching land area from int_gtfs_stops_enriched model and creates int_census_tract_land_area_enriched. This will prevent an issue of census tracts without stops having no land area.